### PR TITLE
Cleanup MIPS Address Space, re-use IA32PagedMemory.

### DIFF
--- a/rekall/plugins/core.py
+++ b/rekall/plugins/core.py
@@ -283,7 +283,7 @@ class FindDTB(plugin.PhysicalASMixin, plugin.ProfileCommand):
                 impl = "WindowsIA32PagedMemoryPae"
 
         elif architecture == "MIPS":
-            impl = "MipsAddressSpace"
+            impl = "MIPS32PagedMemory"
 
         else:
             impl = 'IA32PagedMemory'

--- a/rekall/plugins/renderers/json_storage.py
+++ b/rekall/plugins/renderers/json_storage.py
@@ -111,7 +111,7 @@ class IA32PagedMemoryObjectRenderer(
 
 class MIPSPagedMemoryObjectRenderer(
         json_renderer.BaseAddressSpaceObjectRenderer):
-    renders_type = "MipsAddressSpace"
+    renders_type = "MIPS32PagedMemory"
 
     def GetState(self, item, **options):
         state = super(MIPSPagedMemoryObjectRenderer, self).GetState(


### PR DESCRIPTION
Reworked the MIPS address space to use the IA32PagedMemory as the base. Had to split the entry_present() of IA32PagedMemory into different versions for each level (pde/pte/...) as the MIPS Address Space has to force the pde_entry_present to always be true.

I'm not sure if the EPT version should be the same for all levels, please have a look at that part!
