### PR TITLE
_iat_scan fixed

### DIFF
--- a/rekall/plugins/windows/malware/impscan.py
+++ b/rekall/plugins/windows/malware/impscan.py
@@ -151,6 +151,7 @@ class ImpScan(common.WinProcessFilter):
             offset=start_addr, vm=addr_space, target="Pointer",
             count=iat_size, target_args=dict(target="Function"))
 
+        size_of_address = self.profile.get_obj_size("address")
         # We can not iterate over the iat since there may be some unpaged
         # entries.
         for i in range(0x2000):
@@ -158,14 +159,15 @@ class ImpScan(common.WinProcessFilter):
             func = func_pointer.dereference()
 
             if (not func or
-                    func.obj_offset < base_address or
-                    func.obj_offset > end_address):
+                    (func.obj_offset > base_address and
+                    func.obj_offset < end_address)): # skip call to self
                 continue
 
             # Add the export to our database of imported calls.
             if (func.obj_offset in apis and
                     func.obj_offset not in calls_imported):
-                calls_imported[func.obj_offset] = (func_pointer, func)
+                addr = start_addr + (i * size_of_address)
+                calls_imported[addr] = (func_pointer, func.obj_offset)
 
     def _original_import(self, mod_name, func_name):
         """Revert a forwarded import to the original module
@@ -234,11 +236,11 @@ class ImpScan(common.WinProcessFilter):
 
         # Scan the IAT for additional functions.
         self._iat_scan(task_space, calls_imported, apis,
-                       base_address, size_to_read)
+                       base_address, base_address + size_to_read)
 
         for iat, (address, func_pointer) in sorted(calls_imported.items()):
-            if func_pointer.v() in apis:
-                module, func_pointer, func_name = apis.get(func_pointer.v())
+            if func_pointer in apis:
+                module, func_pointer, func_name = apis.get(func_pointer)
 
                 yield iat, func_pointer, module, func_name
 


### PR DESCRIPTION
I've fixed the bug in _iat_scan. 
The fix enables to find API entries not included in ones resolved by call_scan.

before the fix:
![thebug](https://cloud.githubusercontent.com/assets/6092487/6611143/e009d04a-c8ab-11e4-9927-cc91ffa07952.png)

after the fix:
![fixed](https://cloud.githubusercontent.com/assets/6092487/6611145/ed101ace-c8ab-11e4-93b1-bef2017390a5.png)

Practically, the malware dynamically resolves API func addresses when needed like this:
![ida](https://cloud.githubusercontent.com/assets/6092487/6611147/f2f5ee1e-c8ab-11e4-8ee6-53a4e8fd2fb0.png)

I can provide the memory image, malware sample and its .idb file.