### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/rekall-core/rekall/resources.py
+++ b/rekall-core/rekall/resources.py
@@ -54,7 +54,7 @@ def get_resource(filename, package="rekall-core", prefix="resources"):
     # Installing from wheel places data_files relative to sys.prefix and not
     # site-packages. If we can not find in site-packages, check sys.prefix
     # instead.
-    # http://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#data-files
+    # https://python-packaging-user-guide.readthedocs.io/en/latest/distributing/#data-files
     target = os.path.join(sys.prefix, prefix, filename)
     if target and os.access(target, os.R_OK):
         return target


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.