### PR TITLE
fixing local path error

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ New python executable in /tmp/MyEnv/bin/python
 Installing setuptools, pip...done.
 $ source /tmp/MyEnv/bin/activate
 $ pip install --upgrade setuptools pip wheel
+$ git clone https://github.com/google/rekall.git rekall
 $ pip install --editable rekall/rekall-core
 $ pip install --editable rekall/rekall-agent
 $ pip install --editable rekall


### PR DESCRIPTION
If `pip install --editable rekall/rekall-core` is done before cloning the git repo you will have an error:
`rekall/rekall-core should either be a path to a local project or a VCS url beginning with svn+, git+, hg+, or bzr+`.