### PR TITLE
Bug fix with incorrect driver_path used in (un)loading of MacPmem tgz

### DIFF
--- a/rekall-core/rekall/plugins/tools/live_darwin.py
+++ b/rekall-core/rekall/plugins/tools/live_darwin.py
@@ -92,7 +92,7 @@ class Live(plugin.TypedProfileCommand,
 
     def load_driver(self):
         """Unpack and load the driver."""
-        tarfile_handle = tarfile.open(self.plugin_args.driver_path)
+        tarfile_handle = tarfile.open(self.driver_path)
 
         # Try to extract the resource into a tempdir.
         with utils.TempDirectory() as tmp_name:
@@ -144,7 +144,7 @@ class Live(plugin.TypedProfileCommand,
                                       self.plugin_args.mode)
 
     def unload_driver(self):
-        tarfile_handle = tarfile.open(self.plugin_args.driver_path)
+        tarfile_handle = tarfile.open(self.driver_path)
 
         for member_name in tarfile_handle.getnames():
             if not member_name.endswith(".kext"):


### PR DESCRIPTION
Discovered rekall --live Memory was unable to load the MacPmem driver due to a None value being passed to tarfile.open() using self.arg_parse.driver_path, instead of the MacPmem.kext.tgz archive value with self.driver_path as set by.

```
        self.driver_path = (self.plugin_args.driver_path or
                            resources.get_resource("MacPmem.kext.tgz"))

```