### PR TITLE
DumpFiles Error - Possible Solution

### DIFF
--- a/rekall-core/rekall/plugins/windows/cache.py
+++ b/rekall-core/rekall/plugins/windows/cache.py
@@ -159,8 +159,6 @@ class DumpFiles(core.DirectoryDumperMixin, common.WinProcessFilter):
 
     def CollectFileObject(self):
         """Collect all known file objects."""
-        self.file_objects = set()
-        self.vacb_by_cache_map = {}
 
         # Collect known file objects for selected processes.
         for task in self.filter_processes():
@@ -244,6 +242,10 @@ class DumpFiles(core.DirectoryDumperMixin, common.WinProcessFilter):
                     f_length=0x1000, filename="")
 
     def collect(self):
+        
+        self.file_objects = set()
+        self.vacb_by_cache_map = {}
+        
         renderer = self.session.GetRenderer()
         if not self.plugin_args.file_objects:
             self.CollectFileObject()


### PR DESCRIPTION
Issue solved:
https://groups.google.com/forum/#!topic/rekall-discuss/JrGJklNVUOA

Issue:

If you use rekall and you specify directly the file_object address:
dumpfiles(file_objects=0x81e7f8d8)


Rekall console:
AttributeError: 'DumpFiles' object has no attribute 'vacb_by_cache_map'
[1] cridex.vmem 12:01:23> dumpfiles(file_objects=0x81e7f8d8)
Type Phys Offset File Offset File Length Filename

As you can see in the collect function self.CollectFileObject() is not executed: (https://github.com/google/rekall/blob/fe4e7c6d639dd691c7e6eeacac8cfcc2fbe0ac41/rekall-core/rekall/plugins/windows/cache.py)

And the vacb_by_cache_map is never created:

def CollectFileObject(self):
    """Collect all known file objects."""
    self.file_objects = set()
    self.vacb_by_cache_map = {}

Solution:

Move this lines from CollectFileObject:
self.file_objects = set()
self.vacb_by_cache_map = {}

To the start of the DumpFiles->collect() function.