### PR TITLE
Updated Makefile to fix errors with "make profile"

### DIFF
--- a/tools/linux/Makefile
+++ b/tools/linux/Makefile
@@ -25,7 +25,7 @@ dwarf: module.c
 	$(MAKE) -C $(KHEADER) CONFIG_DEBUG_INFO=y M=$(PWD) modules
 	cp module.ko module_dwarf.ko
 
-profile: dwarf
+profile: dwarf pmem
 	zip "$(KVER).zip" module_dwarf.ko $(KSYSTEMMAP) $(KCONFIG) "pmem-$(KVER).ko"
 
 clean:


### PR DESCRIPTION
As referenced in https://github.com/google/rekall-profiles/issues/21, when running `sudo make profile` the pmem.ko is not renamed to "pmem-$(KVER).ko" causing an error with the zip command on line 29.

This patch allows the pmem to be copied appropriately.