### PR TITLE
Fix zone check

### DIFF
--- a/rekall-core/rekall/plugins/darwin/zones.py
+++ b/rekall-core/rekall/plugins/darwin/zones.py
@@ -64,7 +64,7 @@ class AbstractZoneElementFinder(common.AbstractDarwinParameterHook):
             "(select zone from zones() where zone.name == ?).zone",
             query_parameters=[self.zone_name]).first_result
 
-        if zone is None:
+        if not zone:
             raise ValueError("Zone %r doesn't exist." % self.zone_name)
 
         results = set()

--- a/rekall-core/setup.py
+++ b/rekall-core/setup.py
@@ -73,7 +73,7 @@ install_requires = [
     # https://github.com/pyinstaller/pyinstaller/issues/1848
     "python-dateutil == 2.5.3",
 
-    "rekall-lib >= 1.61, < 1.7",
+    "rekall-lib >= 1.6.1, < 1.7",
 ]
 
 if "VIRTUAL_ENV" not in os.environ:


### PR DESCRIPTION
Found that the zone check was giving a false positive. 
```  File "/home/seren/venv/local/lib/python2.7/site-packages/rekall/plugins/darwin/zones.py", line 72, in calculate
    for offset in zone.known_offsets:
AttributeError: 'list' object has no attribute 'known_offsets'

> /home/seren/venv/local/lib/python2.7/site-packages/rekall/plugins/darwin/zones.py(72)calculate()
-> for offset in zone.known_offsets:
(Pdb) zone
[]
(Pdb) bool(zone)
False
(Pdb) zone is None
False
(Pdb)
```
Changed the check to be `True` if there is an empty array for `zone`

Also fixed the typo in the version for `rekall-lib`