### PR TITLE
Fix regdump for windows 10

### DIFF
--- a/rekall-core/rekall/plugins/windows/registry/registry.py
+++ b/rekall-core/rekall/plugins/windows/registry/registry.py
@@ -220,6 +220,8 @@ class HiveAddressSpace(HiveBaseAddressSpace):
         else:
             yield "\0" * self.BLOCK_SIZE
 
+        last_paddr = 0
+        read_times = 0
         length = self.hive.Hive.Storage[0].Length.v()
         for i in xrange(0, length, self.BLOCK_SIZE):
             paddr = self.vtop(i)
@@ -229,7 +231,12 @@ class HiveAddressSpace(HiveBaseAddressSpace):
                 data = '\0' * self.BLOCK_SIZE
             else:
                 paddr = paddr - 4
-                data = self.base.read(paddr, self.BLOCK_SIZE)
+                if paddr == last_paddr:
+                    read_times += 1
+                else:
+                    read_times = 0
+                last_paddr = paddr
+                data = self.base.read(paddr + self.BLOCK_SIZE*read_times, self.BLOCK_SIZE)
                 if not data:
                     self.logging.warn("Physical layer returned None for index "
                                  "{0:x}, filling with NULL".format(i))


### PR DESCRIPTION
Fix function `save` in class `HiveAddressSpace` in rekall-core/rekall/plugins/windows/registry/registry.py for Windows 10.

We can call function `vtop(i)` in function `save` for getting hbin address in structure `_HMAP_ENTRY `, but in Windows 10, the hbin address stroed in different way.
The origin code would make mistake in Windwos 10 (including x86 and x64): When size of hbin is greater than a BLOCK_SIZE, the content of hbin that offset greater than a BLOCK_SIZE will repeat the first block.

The following is what happened:

`define BLOCK_SIZE 0x1000` and consider `hbin size > BLOCK_SIZE` :
Before Windows 10, hbin address is stored in `_HMAP_ENTRY` field `BlockAddress` in `_HMAP_TABLE`. This design indicates that the stored address is `block address`,  it means that the address is placed in the specific hbin block.
But in Windows 10, the hbin address is stored in `_HMAP_ENTRY` field `PermanentBinAddress`.
The different between `BlockAddress` and `PermanentBinAddress` : `PermanentBinAddress` field always stores the beginning of hbin!
So, the hbin address in `_HMAP_ENTRY` in `_HMAP_TABLE` could be repeated in Windows 10, which causes dumping registry hbin will be wrong (part of the data repeat & part lost).

E.g. 
When hbin size is 2 times BLOCK_SIZE, then there are two `_HMAP_ENTRY` record in `_HMAP_TABLE` pointering to the same hbin.
Before Windows 10, the second hbin address is pointering to the address which offset to beginning of the hbin one BLOCK_SIZE.
But in Windows 10 in this case, the first address and the second address will be very close almost the same (the address difference is less than 0x10).
It causes parsing wrong hbin data.

I fix this mistake and do not affect other Windows versions.