### PR TITLE
Fixed crash caused by passing NoneObject to capstone.

### DIFF
--- a/rekall-core/rekall/plugins/linux/elf.py
+++ b/rekall-core/rekall/plugins/linux/elf.py
@@ -117,7 +117,7 @@ class ELFVerSymbols(ELFPlugins):
                 needed = aux = None
                 filename = symbol_name = ""
 
-            yield dict(symbol=symbol_record,
+            yield dict(elf64_sym=symbol_record,
                        file=filename,
                        Version=symbol_name,
                        other_id=other_ref,

--- a/rekall-core/rekall/plugins/tools/disassembler.py
+++ b/rekall-core/rekall/plugins/tools/disassembler.py
@@ -577,6 +577,8 @@ class Function(obj.BaseAddressComparisonMixIn, obj.BaseObject):
         while 1:
             # By default read 2 pages.
             data = self.obj_vm.read(buffer_offset, 0x2000)
+            if data == None:
+                return
 
             for instruction in self.dis.disassemble(data, buffer_offset):
                 offset = instruction.address


### PR DESCRIPTION
Whan an address space is not found, the physical address space is set
to a NoneObject. Any read() operations on it also return a
NoneObject. Although in Rekall NoneObjects are functionally the same
as None, when passed to distorm's c bindings it causes a segfault.

Issue #345 