### PR TITLE
#458 Timestamp fix for garbage WinFileTime Values

### DIFF
--- a/rekall-core/rekall/plugins/overlays/basic.py
+++ b/rekall-core/rekall/plugins/overlays/basic.py
@@ -670,7 +670,7 @@ class UnixTimeStamp(obj.NativeType):
         try:
             # Return a data time object in UTC.
             return arrow.Arrow.utcfromtimestamp(self.v())
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError ,OSError) as e:
             return obj.NoneObject("Datetime conversion failure: " + str(e))
 
     def as_datetime(self):


### PR DESCRIPTION
Plugins like netscan , psxview , pslist may list closed connections / processes as well. 
In such case where we find a running process/active connection , we get a valid timestamp from memory (in this case epoch time ).
However, closed processes/connections have a garbage value which cannot be resolved to a valid time stamp. 
In such cases we should simply return none object and not run into any error.


