### PR TITLE
this fix prevents an empty/null byte filename

### DIFF
--- a/rekall-core/rekall/plugins/overlays/windows/common.py
+++ b/rekall-core/rekall/plugins/overlays/windows/common.py
@@ -1263,8 +1263,9 @@ class _FILE_OBJECT(ObjectMixin, obj.Struct):
             if device_name:
                 name = u"\\Device\\{0}".format(device_name)
 
-        if self.FileName:
-            name += utils.SmartUnicode(self.FileName)
+        filename = self.get_filename()
+        if filename:
+            name += utils.SmartUnicode(filename)
 
         return name
 

--- a/rekall-core/rekall/plugins/overlays/windows/common.py
+++ b/rekall-core/rekall/plugins/overlays/windows/common.py
@@ -1291,12 +1291,20 @@ class _FILE_OBJECT(ObjectMixin, obj.Struct):
                 if name in drive_letter_device_map:
                     name = drive_letter_device_map.get(name)
 
-        filename = self.FileName.v(vm=vm)
+        filename = self.get_filename(vm=vm)
         if filename:
             name += utils.SmartUnicode(filename)
 
         return name
 
+
+    def get_filename(self, vm=None):
+        filename = self.FileName.v(vm=vm)
+ 
+        if (not filename or filename == "\x00") and self.FileName.Length > 0:
+            filename = "<Filename has probably been paged out>"
+ 
+        return filename
 
 
 class _OBJECT_DIRECTORY(ObjectMixin, obj.Struct):

--- a/rekall-core/rekall/plugins/windows/malware/malfind.py
+++ b/rekall-core/rekall/plugins/windows/malware/malfind.py
@@ -189,7 +189,7 @@ class LdrModules(common.WinProcessFilter):
                 file_obj = vad.ControlArea.FilePointer
                 protect = str(vad.u.VadFlags.ProtectionEnum)
                 if "EXECUTE" in protect and "WRITE" in protect:
-                    yield vad, file_obj.FileName
+                    yield vad, file_obj.file_name_with_drive()
             except AttributeError:
                 pass
 

--- a/rekall-core/rekall/plugins/windows/registry/evtlogs.py
+++ b/rekall-core/rekall/plugins/windows/registry/evtlogs.py
@@ -268,7 +268,8 @@ class EvtLogs(registry.RegistryPlugin):
 
         for task, vad in self.FindEVTFiles():
             filename = ntpath.basename(
-                utils.SmartUnicode(vad.ControlArea.FilePointer.FileName))
+                utils.SmartUnicode(
+                    vad.ControlArea.FilePointer.file_name_with_drive()))
 
             for event in self.ScanEvents(vad, task.get_process_address_space()):
                 renderer.table_row(

--- a/rekall-core/rekall/plugins/windows/vadinfo.py
+++ b/rekall-core/rekall/plugins/windows/vadinfo.py
@@ -131,7 +131,8 @@ class VAD(common.WinProcessFilter):
         try:
             file_obj = vad.ControlArea.FilePointer
             if file_obj:
-                filename = file_obj.FileName or "Pagefile-backed section"
+                filename = (file_obj.file_name_with_drive() or 
+                            "Pagefile-backed section")
         except AttributeError:
             pass
 


### PR DESCRIPTION
if the page containing the filename has been paged out, the FileName field contains just a null byte which leads to certain side effects
e.g. 
- a VAD that appears to be a mapped section backed by the page file, instead of a loaded image/data file
- an exception while trying to dump/disassemble content for that file (see example stack trace output below)

    disassembler.render(renderer, suppress_headers=True)
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/plugins/tools/disassembler.py", line 447, in render
    return super(Disassemble, self).render(renderer, **options)
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/plugin.py", line 761, in render
    for row in self.collect():
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/plugins/tools/disassembler.py", line 460, in collect
    offset)
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/plugins/common/address_resolver.py", line 335, in get_nearest_constant_by_address
    if module.profile != None:
  File "/rekall/lib/python3.7/site-packages/rekall_lib/utils.py", line 1091, in __get__
    return super(safe_property, self).__get__(*args, **kwargs)
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/plugins/windows/address_resolver.py", line 182, in profile
    return self.load_profile(force=False)
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/plugins/windows/address_resolver.py", line 188, in load_profile
    self.session.LoadProfile(profile_name) or
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/session.py", line 968, in LoadProfile
    session=self)
  File "/rekall/lib/python3.7/site-packages/rekall_lib/registry.py", line 96, in __call__
    res = super(UniqueObjectIdMetaclass, cls).__call__(*args, **kwargs)
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/io_manager.py", line 344, in __init__
    self.check_dump_dir(self.dump_dir)
  File "/rekall/lib/python3.7/site-packages/rekall_core-1.7.2rc1-py3.7.egg/rekall/io_manager.py", line 410, in check_dump_dir
    if not os.path.isdir(dump_dir):
  File "/rekall/lib/python3.7/genericpath.py", line 42, in isdir
    st = os.stat(s)
ValueError: embedded null byte