### PR TITLE
Adding pypykatz to plugins for rekall-core

### DIFF
--- a/rekall-core/rekall/plugins/windows/__init__.py
+++ b/rekall-core/rekall/plugins/windows/__init__.py
@@ -41,5 +41,5 @@ from rekall.plugins.windows import ssdt
 from rekall.plugins.windows import taskmods
 from rekall.plugins.windows import vadinfo
 
-if sys.version_info[0] >= 3 and sys.version_info[1] > 5:
+if sys.version_info[0] >= 3 and sys.version_info[1] > 4:
     from rekall.plugins.windows import pypykatz

--- a/rekall-core/rekall/plugins/windows/__init__.py
+++ b/rekall-core/rekall/plugins/windows/__init__.py
@@ -1,4 +1,5 @@
 # pylint: disable=unused-import
+import sys
 
 from rekall.plugins.windows import address_resolver
 from rekall.plugins.windows import cache
@@ -39,3 +40,6 @@ from rekall.plugins.windows import shimcache
 from rekall.plugins.windows import ssdt
 from rekall.plugins.windows import taskmods
 from rekall.plugins.windows import vadinfo
+
+if sys.version_info[0] >= 3 and sys.version_info[1] > 5:
+    from rekall.plugins.windows import pypykatz

--- a/rekall-core/rekall/plugins/windows/pypykatz.py
+++ b/rekall-core/rekall/plugins/windows/pypykatz.py
@@ -1,0 +1,99 @@
+#from builtins import str
+__author__ = ("Tamas Jos <info@skelsec.com>")
+
+from pypykatz.pypykatz import pypykatz
+from pypykatz.commons.readers.rekall.rekallreader import RekallReader
+from pypykatz.commons.common import *
+import json
+import ntpath
+import os
+
+from rekall.plugins.windows import common
+
+
+class Pypykatz(common.WindowsCommandPlugin):
+	"""Extract and decrypt passwords from the LSA Security Service."""
+	"""
+	IMPORTANT: Using the default viewer on rekall will NOT show you all the info!!!
+	Recommendation: Use the out_file and kerberos_dir flags to get all the juicy stuff
+	"""
+
+	__name = "pypykatz"
+
+	__args = [
+		dict(name="override_timestamp", type="int", required=False,
+			 help="The msv dll file timestamp detection fails in some cases."),
+
+		dict(name="out_file", required=False,
+			 help="The file name to write."),
+
+		dict(name="kerberos_dir", required=False,
+			 help="The file name to write."),
+
+		dict(name="json", required=False, type="bool",
+			 help="Write credentials to file in JSON format"),
+
+	]
+
+	table_header = [
+		dict(name='LUID', width=6),
+		dict(name='Type', width=8),
+		dict(name='Sess', width=2),
+		dict(name='SID', width=20),
+		dict(name='Module', width=7),
+		dict(name='Info', width=7),
+		dict(name='Domain', width=16),
+		dict(name='User', width=16),
+		dict(name='SType', width=9),
+		dict(name='Secret', width=80)
+	]
+
+	def __init__(self, *args, **kwargs):
+		super(Pypykatz, self).__init__(*args, **kwargs)
+
+	def collect(self):
+		cc = self.session.plugins.cc()
+		mimi = pypykatz.go_rekall(self.session, self.plugin_args.override_timestamp)
+
+		if self.plugin_args.out_file and self.plugin_args.json:
+			self.session.logging.info('Dumping results to file in JSON format')
+			with open(self.plugin_args.out_file, 'w') as f:
+				json.dump(mimi, f, cls = UniversalEncoder, indent=4, sort_keys=True)
+		
+	
+		elif self.plugin_args.out_file:
+			self.session.logging.info('Dumping results to file')
+			with open(self.plugin_args.out_file, 'w') as f:
+				f.write('FILE: ======== MEMORY =======\n')
+					
+				for luid in mimi.logon_sessions:
+					f.write('\n'+str(mimi.logon_sessions[luid]))
+					
+					if len(mimi.orphaned_creds) > 0:
+						f.write('\n== Orphaned credentials ==\n')
+						for cred in mimi.orphaned_creds:
+							f.write(str(cred))
+		
+		else:
+			self.session.logging.info('Dumping results')
+			for luid in mimi.logon_sessions:
+				for row in mimi.logon_sessions[luid].to_row():
+					yield row
+
+
+		if self.plugin_args.kerberos_dir:
+			directory = os.path.abspath(self.plugin_args.kerberos_dir)
+			self.session.logging.info('Writing kerberos tickets to %s' % directory)
+			base_filename = ntpath.basename('rekall_memory')
+			ccache_filename = '%s_%s.ccache' % (base_filename, os.urandom(4).hex()) #to avoid collisions
+			mimi.kerberos_ccache.to_file(os.path.join(directory, ccache_filename))
+			for luid in mimi.logon_sessions:
+				for kcred in mimi.logon_sessions[luid].kerberos_creds:
+					for ticket in kcred.tickets:
+						ticket.to_kirbi(directory)
+								
+			for cred in mimi.orphaned_creds:
+				if cred.credtype == 'kerberos':
+					for ticket in cred.tickets:
+						ticket.to_kirbi(directory)
+		return

--- a/rekall-core/rekall/plugins/windows/pypykatz.py
+++ b/rekall-core/rekall/plugins/windows/pypykatz.py
@@ -21,8 +21,9 @@ class Pypykatz(common.WindowsCommandPlugin):
 	__name = "pypykatz"
 
 	__args = [
-		dict(name="override_timestamp", type="int", required=False,
-			 help="The msv dll file timestamp detection fails in some cases."),
+		
+		dict(name="buildnumber", type="int", required=False,
+			 help="BuildNumber value of the OS, overrides automatice search for buildnumber"),
 
 		dict(name="out_file", required=False,
 			 help="The file name to write."),
@@ -32,6 +33,9 @@ class Pypykatz(common.WindowsCommandPlugin):
 
 		dict(name="json", required=False, type="bool",
 			 help="Write credentials to file in JSON format"),
+
+		dict(name="override_timestamp", type="int", required=False,
+			 help="The msv dll file timestamp detection fails in some cases."),
 
 	]
 
@@ -53,7 +57,7 @@ class Pypykatz(common.WindowsCommandPlugin):
 
 	def collect(self):
 		cc = self.session.plugins.cc()
-		mimi = pypykatz.go_rekall(self.session, self.plugin_args.override_timestamp)
+		mimi = pypykatz.go_rekall(self.session, self.plugin_args.override_timestamp, self.plugin_args.buildnumber)
 
 		if self.plugin_args.out_file and self.plugin_args.json:
 			self.session.logging.info('Dumping results to file in JSON format')

--- a/rekall-core/setup.py
+++ b/rekall-core/setup.py
@@ -70,6 +70,7 @@ install_requires = [
     'pytz==2017.3',
     'rekall-capstone==3.0.5.post2',
     "rekall-efilter >= 1.6, < 1.7",
+    'pypykatz>=0.0.5;python_version>="3.5"',
 
     # Should match exactly the version of this package.
     'rekall-lib',

--- a/rekall-core/setup.py
+++ b/rekall-core/setup.py
@@ -70,7 +70,7 @@ install_requires = [
     'pytz==2017.3',
     'rekall-capstone==3.0.5.post2',
     "rekall-efilter >= 1.6, < 1.7",
-    'pypykatz>=0.0.5;python_version>="3.5"',
+    'pypykatz>=0.0.6;python_version>="3.5"',
 
     # Should match exactly the version of this package.
     'rekall-lib',

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ install_requires = [
     "rekall-lib >= 1.7.0rc1, < 1.8",
     "rekall-core >= 1.7.0rc1, < 1.8",
     "ipython >= 5.0.0, < 7.0",
-    'pypykatz;python_version>="3.5"',
+    'pypykatz>=0.0.5;python_version>="3.5"',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ install_requires = [
     "rekall-lib >= 1.7.0rc1, < 1.8",
     "rekall-core >= 1.7.0rc1, < 1.8",
     "ipython >= 5.0.0, < 7.0",
+    'pypykatz;python_version>="3.5"',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ install_requires = [
     "rekall-lib >= 1.7.0rc1, < 1.8",
     "rekall-core >= 1.7.0rc1, < 1.8",
     "ipython >= 5.0.0, < 7.0",
-    'pypykatz>=0.0.5;python_version>="3.5"',
+    
 ]
 
 setup(


### PR DESCRIPTION
Based on your response on [Issue 483](https://github.com/google/rekall/issues/483) I'm creating this PR, adding pypykatz command to rekall-core, allowing users to dump secrets from the lsass.exe process on windows including plaintext passwords, hashes, kerberos tickets, DPAPI keys etc.

pypykatz version 0.0.6 has been released on pip at the same time, so installing should be seamless.

I have a problem with providing a machine-parsable output for kerberos tickets, any suggestions welcome. Currently the script only dumps the tickets is the user supplies a folder name to dump the tickets to.

Generally any suggestions welcome, this is my first rekall plugin :)

Best Regards,
SkelSec
