### PR TITLE
Fix kernel panic when try to free null lock

### DIFF
--- a/tools/osx/MacPmem/MacPmem/meta.cpp
+++ b/tools/osx/MacPmem/MacPmem/meta.cpp
@@ -174,10 +174,10 @@ static inline unsigned pmem_metaroom(pmem_meta_t *meta) {
 
         // If we're here it's highly likely the kernel will panic soon.
         // Let's preempt that by blowing up sooner rather than later.
-        panic((BUFFER OVERFLOW DETECTED: Meta %p is of size %u, of which %lu
-               is the base struct, and it contains %d records of combined size
-               of %u, meaning %u bytes have been written past allocated
-               memory.),
+        panic(("BUFFER OVERFLOW DETECTED: Meta %p is of size %u, of which %lu"
+               "is the base struct, and it contains %d records of combined size"
+               "of %u, meaning %u bytes have been written past allocated"
+               "memory."),
               meta, meta->size, sizeof(pmem_meta_t), meta->record_count,
               meta->records_end, -room);
 
@@ -819,8 +819,18 @@ void pmem_meta_cleanup() {
         pmem_sysctl = 0;
     }
 
-    lck_rw_free(pmem_cached_info_lock, pmem_rwlock_grp);
-    lck_attr_free(pmem_cached_info_lock_attr);
+    if (pmem_cached_info_lock != NULL && pmem_rwlock_grp != NULL) {
+        lck_rw_free(pmem_cached_info_lock, pmem_rwlock_grp);
+    }
+    else {
+        pmem_error("Failed to clean pmem_cached_info_lock and pmem_rwlock_grp.");
+    }
+    if (pmem_cached_info_lock_attr != NULL) {
+        lck_attr_free(pmem_cached_info_lock_attr);
+    }
+    else {
+        pmem_error("Failed to clean pmem_cached_info_lock_attr.");
+    }
 }
 
 

--- a/tools/osx/MacPmem/MacPmem/meta.cpp
+++ b/tools/osx/MacPmem/MacPmem/meta.cpp
@@ -174,10 +174,10 @@ static inline unsigned pmem_metaroom(pmem_meta_t *meta) {
 
         // If we're here it's highly likely the kernel will panic soon.
         // Let's preempt that by blowing up sooner rather than later.
-        panic(("BUFFER OVERFLOW DETECTED: Meta %p is of size %u, of which %lu"
-               "is the base struct, and it contains %d records of combined size"
-               "of %u, meaning %u bytes have been written past allocated"
-               "memory."),
+        panic((BUFFER OVERFLOW DETECTED: Meta %p is of size %u, of which %lu
+               is the base struct, and it contains %d records of combined size
+               of %u, meaning %u bytes have been written past allocated
+               memory.),
               meta, meta->size, sizeof(pmem_meta_t), meta->record_count,
               meta->records_end, -room);
 


### PR DESCRIPTION
In some rare case, when loading kext and initialzing phase failed, the `pmem_cleanup` will always be called. And `pmem_cleanup` will always call `pmem_meta_cleanup` who tries to free `pmem_cached_info_lock` in any case. If `pmem_cached_info_lock` hasn't been init before, the call to `lck_rw_free` will cause kernel panic. This bug occurs on my machine and cuases my mac to restart from time to time. It's better to be fixed when you try to dump the memory of a Mac but it paniced and all the memories are gone.