### PR TITLE
Fixes dependency issues for Python3 on Debian 10

### DIFF
--- a/rekall-agent/setup.py
+++ b/rekall-agent/setup.py
@@ -41,7 +41,7 @@ def find_data_files(source):
     return result
 
 install_requires = [
-    "future",
+    "future==0.16.0",
     "rekall-lib >= 1.7.0rc1, < 1.8",
     "sseclient==0.0.18",
     "rekall-core >= 1.7.0rc1, < 1.8",

--- a/rekall-core/setup.py
+++ b/rekall-core/setup.py
@@ -56,12 +56,12 @@ install_requires = [
     'acora==2.1',
     'arrow==0.10.0',
     'artifacts==20170909',
-    'future',
+    'future==0.16.0',
     'intervaltree==2.1.0',
     'ipaddr==2.2.0',
     'parsedatetime==2.4',
     "psutil >= 5.0, < 6.0",
-    'pyaff4 >= 0.26, < 0.30',
+    'pyaff4 ==0.26.post6',
     'pycryptodome==3.4.7',
     'pyelftools==0.24',
     'pyparsing==2.1.5',
@@ -70,7 +70,7 @@ install_requires = [
     'pytz==2017.3',
     'rekall-capstone==3.0.5.post2',
     "rekall-efilter >= 1.6, < 1.7",
-    'pypykatz>=0.0.6;python_version>="3.5"',
+    'pypykatz==0.0.8;python_version>="3.5"',
 
     # Should match exactly the version of this package.
     'rekall-lib',

--- a/rekall-lib/setup.py
+++ b/rekall-lib/setup.py
@@ -42,7 +42,7 @@ def find_data_files(source):
 
 install_requires = [
     "arrow==0.10.0",
-    "future",
+    "future==0.16.0",
     # We need to upgrade but this seems to break Rekall.
     #    "sortedcontainers >= 2.0, < 3.0",
     "sortedcontainers==1.5.7",

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = [
     "rekall-agent >= 1.7.0rc1, < 1.8",
     "rekall-lib >= 1.7.0rc1, < 1.8",
     "rekall-core >= 1.7.0rc1, < 1.8",
-    "ipython >= 5.0.0, < 7.0",
+    "ipython== 5.8.0",
     
 ]
 


### PR DESCRIPTION
Should fix the following issues #495, #510, #513, #519 and probably #474 and #488.

Tested on Python version 3.7.3 and Debian 10.2 (aka Buster).

Execution of plugin `psxview` using the VMI FileAddressSpace for a live VM (Xen DomU):
```
(analyzer) root@xen-devel:/home/aandres/github/rekall# rekal -f vmi:///win7-sp1-x64-20
Webconsole disabled: cannot import name 'webconsole_plugin' from 'rekall.plugins.tools' (/opt/batch/analyzer/rekall-github/rekall-core/rekall/plugins/tools/__init__.py)
 Scanning buffer 0x2800000->0x3200000 (0xa00000)
----------------------------------------------------------------------------
The Rekall Digital Forensic/Incident Response framework 1.7.3.dev58 (Hurricane Ridge).

"We can remember it for you wholesale!"

This program is free software; you can redistribute it and/or modify it under
the terms of the GNU General Public License.

See http://www.rekall-forensic.com/docs/Manual/tutorial.html to get started.
----------------------------------------------------------------------------
[1] win7-sp1-x64-20 13:11:52> psxview
----------------------------> psxview()
  _EPROCESS            name          pid  PsActiveProcessHead CSRSS PspCidTable Sessions Handles PSScan Thrdproc
-------------- -------------------- ----- ------------------- ----- ----------- -------- ------- ------ --------
0xfa8001e249e0 System                   4 True                False True        False    False   True   True
0xfa8002eb5b30 smss.exe               220 True                False True        False    True    True   True
0xfa8003b3ab30 spoolsv.exe            272 True                True  True        True     True    True   True
0xfa80038747b0 csrss.exe              296 True                False True        True     True    True   True
0xfa8003966b30 slui.exe               304 True                True  True        True     True    True   True
0xfa80038d4b30 wininit.exe            356 True                True  True        True     True    True   True
0xfa8003889b30 services.exe           444 True                True  True        True     True    True   True
0xfa8003904850 lsass.exe              452 True                True  True        True     True    True   True
[snipped for brevity]
```

...and the same execution but now using a raw memory file:
```
(analyzer) root@xen-devel:/home/aandres/github/rekall# rekal -f /opt-hdd/dist/ramdisk/base/ram/win7-sp1-x64/mem-rekall.bin
Webconsole disabled: cannot import name 'webconsole_plugin' from 'rekall.plugins.tools' (/opt/batch/analyzer/rekall-github/rekall-core/rekall/plugins/tools/__init__.py)
 Scanning buffer 0xa00000->0x1400000 (0xa00000)
----------------------------------------------------------------------------
The Rekall Digital Forensic/Incident Response framework 1.7.3.dev58 (Hurricane Ridge).

"We can remember it for you wholesale!"

This program is free software; you can redistribute it and/or modify it under
the terms of the GNU General Public License.

See http://www.rekall-forensic.com/docs/Manual/tutorial.html to get started.
----------------------------------------------------------------------------
[1] mem-rekall.bin 13:23:39> psxview
---------------------------> psxview()
  _EPROCESS            name          pid  PsActiveProcessHead CSRSS PspCidTable Sessions Handles PSScan Thrdproc
-------------- -------------------- ----- ------------------- ----- ----------- -------- ------- ------ --------
0xfa8001e289e0 System                   4 True                False True        False    False   True   True
0xfa8003a7cb30 svchost.exe            200 True                True  True        True     True    True   True
0xfa8002b14310 smss.exe               220 True                False True        False    True    True   True
0xfa8003b8e910 taskhost.exe           272 True                True  True        True     True    True   True
0xfa80035ae720 csrss.exe              300 True                False True        True     True    True   True
0xfa80038a9060 wininit.exe            348 True                True  True        True     True    True   True
0xfa80038a0060 csrss.exe              360 True                False True        True     True    True   True
0xfa80038c7760 winlogon.exe           396 True                True  True        True     True    True   True
[snipped for brevity]
```

Regards