### PR TITLE
fixes bug in VA translation process

### DIFF
--- a/rekall-core/rekall/plugins/addrspaces/amd64.py
+++ b/rekall-core/rekall/plugins/addrspaces/amd64.py
@@ -98,6 +98,7 @@ class AMD64PagedMemory(intel.IA32PagedMemoryPae):
 
         if not pdpte_value & self.valid_mask:
             collection.add(intel.InvalidAddress, "Invalid PDPTE\n")
+            return collection
 
         # Large page mapping.
         if pdpte_value & self.page_size_mask:


### PR DESCRIPTION
The current implementation continues on an invalid PDPTE, leading in some cases to falsely valid PDE/PTEs and hence to returning memory where no memory should be.

For comparison regarding fix see: https://github.com/f-block/rekall/blob/master/rekall-core/rekall/plugins/addrspaces/intel.py#L363